### PR TITLE
Add Error Handling

### DIFF
--- a/WhatsThatThing/Controllers/HomeController.cs
+++ b/WhatsThatThing/Controllers/HomeController.cs
@@ -52,8 +52,23 @@ namespace WhatsThatThing.Controllers
             };
             //
             Path.GetFileName(imageUrl);
+            
+            // Redirects to Invalid Image view if Computer Vision returns an error
+            // Assumes Error is due to a bad image url - is not of a direct image e.g., google.com
+            try
+            {
             ImageAnalysis results = await client.AnalyzeImageAsync(imageUrl, features);
             return View(results);
+            }
+            catch (Exception e)
+            {
+                return RedirectToAction("InvalidImage");
+            }
+        }
+
+        public IActionResult InvalidImage()
+        {
+            return View();
         }
     }
 }

--- a/WhatsThatThing/Views/Home/InvalidImage.cshtml
+++ b/WhatsThatThing/Views/Home/InvalidImage.cshtml
@@ -1,0 +1,7 @@
+<h1>Unsupported Image Type</h1>
+<hr>
+
+<h3>Oops! The URL you entered is not a valid image type!</h3>
+<h3>Please submit a direct link to a .jpeg, .png, or a .bmp image file</h3>
+
+<h3>@Html.ActionLink("Return to Submission Page?", "Index")</h3>


### PR DESCRIPTION
If Computer Vision (Details route) throws an error, user is redirected to the InvalidImage view, which reiterates the required file type/format.